### PR TITLE
ko 缺少处理类型为 ico 的资源文件配置

### DIFF
--- a/packages/ko/src/webpack/loaders/asset.ts
+++ b/packages/ko/src/webpack/loaders/asset.ts
@@ -7,7 +7,7 @@ const assetModules = [
     },
   },
   {
-    test: /\.(png|jpg|jpeg|gif|webp|svg)$/i,
+    test: /\.(png|jpg|jpeg|gif|webp|svg|ico)$/i,
     type: 'asset/resource',
     generator: {
       filename: 'images/[hash][ext][query]',


### PR DESCRIPTION
导致 ico 文件处于打包文件的根路径，希望 ico 文件能够和别的文件一样，放到 images 下面
<img width="323" alt="image" src="https://user-images.githubusercontent.com/38368040/183898783-7b318ba8-2e04-4dcb-a004-85f6af6b4885.png">
