### PR TITLE
feat: serve add historyApiFallback parameter

### DIFF
--- a/.changeset/cool-olives-sell.md
+++ b/.changeset/cool-olives-sell.md
@@ -1,0 +1,5 @@
+---
+'ko': patch
+---
+
+devserver added historyApiFallback configuration to resolve resource path 404 issues

--- a/packages/ko/src/actions/dev.ts
+++ b/packages/ko/src/actions/dev.ts
@@ -15,7 +15,7 @@ class Dev extends ActionFactory {
 
   private get devServerConfig(): DevServerConfiguration {
     const { serve, publicPath, logLevel } = this.service.config;
-    const { host, port, proxy, staticPath } = serve;
+    const { host, port, proxy, staticPath, historyApiFallback = false } = serve;
     return {
       port,
       host,
@@ -32,6 +32,7 @@ class Dev extends ActionFactory {
         overlay: false,
         logging: logLevel,
       },
+      historyApiFallback,
     };
   }
 

--- a/packages/ko/src/types.ts
+++ b/packages/ko/src/types.ts
@@ -29,6 +29,7 @@ export type IOptions = {
     host: string;
     port: number;
     staticPath?: string;
+    historyApiFallback?: any;
   };
   // experimental features
   experiment?: {


### PR DESCRIPTION
## 背景
如果使用 react-router-dom 来配置路由跳转，使用 BrowserRouter 时匹配 / 以外的路由会找不到服务而报 404 错误

这是因为 react 服务是一个单页面应用，使用 BrowserRouter 模式会向浏览器请求指定的路由资源，如访问 xxx 路由相当于请求服务端的 ~/xxx 资源，但是服务端并没有配置该路由，因此会返回 404，

## 解决方案
serve 增加 historyApiFallback 配置。

webpack参数说明：https://webpack.docschina.org/configuration/dev-server/#devserverhistoryapifallback
