### PR TITLE
Fix antlr4

### DIFF
--- a/.changeset/proud-crabs-double.md
+++ b/.changeset/proud-crabs-double.md
@@ -1,0 +1,5 @@
+---
+'ko': patch
+---
+
+transform antlr4-c3 file &&=

--- a/.changeset/proud-crabs-double.md
+++ b/.changeset/proud-crabs-double.md
@@ -1,5 +1,0 @@
----
-'ko': patch
----
-
-transform antlr4-c3 file &&=

--- a/packages/ko/CHANGELOG.md
+++ b/packages/ko/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ko
 
+## 6.5.9
+
+### Patch Changes
+
+- fa12b04b8: transform antlr4-c3 file &&=
+
 ## 6.5.8
 
 ### Patch Changes

--- a/packages/ko/package.json
+++ b/packages/ko/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ko",
-  "version": "6.5.8",
+  "version": "6.5.9",
   "description": "build & lint library",
   "keywords": [
     "ko",

--- a/packages/ko/src/webpack/loaders/script.ts
+++ b/packages/ko/src/webpack/loaders/script.ts
@@ -28,6 +28,8 @@ class Script {
           // internal modules dt-common compatible
           if (input.includes('node_modules/dt-common/src/')) {
             return true;
+          } else if (input.includes('antlr4-c3')) {
+            return true;
           } else if (input.includes('node_modules')) {
             return false;
           } else {


### PR DESCRIPTION
![image](https://github.com/DTStack/ko/assets/38368040/88198b9f-fc51-41ff-b5a4-08f84bbbe0ec)

实时应用中发现 antlr4-c3 中，有 &&= 运算符尚未被编译，导致低于85的浏览器报错。