### PR TITLE
Add htmlChunks configuration item

### DIFF
--- a/.changeset/fifty-tools-return.md
+++ b/.changeset/fifty-tools-return.md
@@ -1,0 +1,5 @@
+---
+'ko': patch
+---
+
+add htmlChunks to configure the chunks of HtmlWebpackPlugin

--- a/packages/ko/src/types.ts
+++ b/packages/ko/src/types.ts
@@ -15,6 +15,7 @@ export type IOptions = {
   externals?: Record<string, string>;
   plugins?: HookOptions[];
   htmlTemplate?: string;
+  htmlChunks?: 'all' | string[];
   // style configs
   analyzer?: boolean;
   extraPostCSSPlugins?: Plugin[];

--- a/packages/ko/src/webpack/plugins.ts
+++ b/packages/ko/src/webpack/plugins.ts
@@ -16,11 +16,18 @@ function getPlugins(opts: IWebpackOptions) {
   const {
     isProd,
     htmlTemplate,
+    htmlChunks,
     copy,
     analyzer,
     autoPolyfills,
     serve: { host, port, compilationSuccessInfo },
   } = opts;
+  const htmlOptions: HtmlWebpackPlugin.Options = {
+    template: htmlTemplate,
+  };
+  if (htmlChunks) {
+    htmlOptions.chunks = htmlChunks;
+  }
   return [
     new IgnorePlugin({
       resourceRegExp: /^\.\/locale$/,
@@ -71,9 +78,7 @@ function getPlugins(opts: IWebpackOptions) {
         chunkFilename: 'css/[id].[contenthash].css',
       }),
     new CaseSensitivePathsPlugin(),
-    new HtmlWebpackPlugin({
-      template: htmlTemplate,
-    }),
+    new HtmlWebpackPlugin(htmlOptions),
     copy &&
       new CopyWebpackPlugin({
         patterns: copy,

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -18,6 +18,7 @@ export type IOptions = {
   externals?: Record<string, string>; //excluding dependencies from the output bundles
   plugins?: any[]; // ko internal plugins, you can define your own plugin of ko.
   htmlTemplate?: string; //output html file template 
+  htmlChunks?: 'all' | string[]; // add only some chunks to html
   // style configs
   analyzer?: boolean; // show output files with an interactive zoomable treemap
   extraPostCSSPlugins?: Plugin[]; // extra post css plugins

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/configuration.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/configuration.md
@@ -18,6 +18,7 @@ export type IOptions = {
   externals?: Record<string, string>; // 从输出的Bundle中需要排除的依赖
   plugins?: any[]; // ko 内部插件，您可以定义自己的 ko 插件。
   htmlTemplate?: string; // 输出 HTML 文件模板
+  htmlChunks?: 'all' | string[]; // 添加到 HTML 中的 chunk
   // 样式配置
   analyzer?: boolean; // 显示带有可缩放的交互式树状图的输出文件
   extraPostCSSPlugins?: Plugin[]; // 额外的 postcss 插件


### PR DESCRIPTION
变更：添加htmlChunks配置项，用来配置html-webpack-plugin的chunks配置项。

背景说明：添加该配置项是为了解决在portal中，module federation 自动在html中注入remoteEntry.js文件，导致热更新和懒加载报错。所以需要通过配置chunks，来阻止自动注入remoteEntry.js文件。
