### PR TITLE
fix: #167 support window path with \\

### DIFF
--- a/.changeset/purple-rings-attend.md
+++ b/.changeset/purple-rings-attend.md
@@ -1,0 +1,5 @@
+---
+'ko': patch
+---
+
+support window path with \\

--- a/packages/ko/src/webpack/loaders/script.ts
+++ b/packages/ko/src/webpack/loaders/script.ts
@@ -17,7 +17,7 @@ class Script {
         test: /\.worker.[jt]s$/,
         loader: this.WORKER_LOADER,
         include: (input: string) =>
-          input.includes('dt-react-monaco-editor/lib/languages'),
+          /dt-react-monaco-editor[\\/]lib[\\/]languages/.test(input),
         options: {
           inline: 'fallback',
         },
@@ -26,7 +26,7 @@ class Script {
         test: /\.m?(t|j)sx?$/,
         include: (input: string) => {
           // internal modules dt-common compatible
-          if (input.includes('node_modules/dt-common/src/')) {
+          if (/node_modules[\\/]dt-common[\\/]src[\\/]/.test(input)) {
             return true;
           } else if (input.includes('antlr4-c3')) {
             return true;


### PR DESCRIPTION
Windows 上本地运行时打印 input，虽然显示的路径分隔符是 `\`，但这是转义后显示的，匹配时需要使用 `\\`

<img width="1796" alt="image" src="https://github.com/user-attachments/assets/6a040102-2a62-48c9-a380-13e69361875a">
