### PR TITLE
fix: #176, remove compilationSuccessInfo in serverConfig to pass sche…

### DIFF
--- a/.changeset/metal-plums-turn.md
+++ b/.changeset/metal-plums-turn.md
@@ -1,0 +1,5 @@
+---
+'ko': patch
+---
+
+remove compilationSuccessInfo in serverConfig to pass schema validate

--- a/packages/ko/src/actions/dev.ts
+++ b/packages/ko/src/actions/dev.ts
@@ -8,6 +8,7 @@ import ActionFactory from './factory';
 import { ICliOptions } from '../types';
 import detect from 'detect-port';
 import inquirer from 'inquirer';
+import { omit } from 'lodash';
 
 class Dev extends ActionFactory {
   private webpackConfig: WebpackConfig;
@@ -137,11 +138,12 @@ class Dev extends ActionFactory {
     process.env.NODE_ENV = 'development';
     this.service.freezeCliOptsWith(cliOpts);
     const config = await this.generateConfig();
-    const port = config.devServer?.port as number;
+    const serverConfig = omit(config.devServer, 'compilationSuccessInfo');
+    const port = serverConfig.port as number;
     const newPort = (await this.checkPort(port)) as number;
     const compiler = Webpack(config);
     const devServer = new WebpackDevServer(
-      { ...config.devServer, port: newPort },
+      { ...serverConfig, port: newPort },
       compiler
     );
     await devServer.start();

--- a/packages/ko/src/types.ts
+++ b/packages/ko/src/types.ts
@@ -2,7 +2,17 @@ import { Pattern } from 'copy-webpack-plugin';
 import { Plugin } from 'postcss';
 import { IKeys, IOpts } from 'ko-lints';
 import { IOpts as AutoPolyfillsWebpackPluginOptions } from '@dtinsight/auto-polyfills-webpack-plugin';
-import { ClientConfiguration } from 'webpack-dev-server';
+import { ClientConfiguration, Configuration as WebpackDevServerConfiguration } from 'webpack-dev-server';
+
+export interface IServeConfig extends WebpackDevServerConfiguration {
+  proxy?: Record<string, any>;
+  host: string;
+  port: number;
+  staticPath?: string;
+  client?: boolean | ClientConfiguration | undefined;
+  historyApiFallback?: any;
+  compilationSuccessInfo?: { messages: string[]; notes?: string[] };
+}
 
 export type IOptions = {
   //common configs
@@ -88,17 +98,9 @@ export type IOptions = {
   /**
    * Options for the development server.
    * Docs url: https://webpack.js.org/configuration/dev-server/
-   * @param {{proxy?: Record<string, any>, host: string, port: number, staticPath?: string, historyApiFallback?: any, compilationSuccessInfo?: { messages: string[]; notes?: string[] }}}
+   * @param {IServeConfig}
    */
-  serve: {
-    proxy?: Record<string, any>;
-    host: string;
-    port: number;
-    staticPath?: string;
-    client?: boolean | ClientConfiguration | undefined;
-    historyApiFallback?: any;
-    compilationSuccessInfo?: { messages: string[]; notes?: string[] };
-  };
+  serve: IServeConfig;
   // experimental features
   /**
    * Experimental features to enable.

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -36,6 +36,7 @@ export type IOptions = {
     staticPath?: string; // static path that will be watch of dev server
     client?: boolean | ClientConfiguration | undefined; // client of dev server
     compilationSuccessInfo?: { messages: string[]; notes?: string[] }; // log after successful compilation, as same as friendly-errors-webpack-plugin
+    // other all webpack-dev-server supported configs
   };
   // experimental features
   experiment?: {

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/configuration.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/configuration.md
@@ -34,6 +34,7 @@ export type IOptions = {
     staticPath?: string; // 监视的资源路径
     client?: boolean | ClientConfiguration | undefined; // 日志、错误捕获等配置项
     compilationSuccessInfo?: { messages: string[]; notes?: string[] }; // 成功编译后的日志，与 friendly-errors-webpack-plugin 相同
+    // 其他所有 webpack-dev-server 支持的配置项
   };
   // 实验性功能
   experiment?: {


### PR DESCRIPTION
Fix #176 

问题原因：
6.6.3近几个版本升级了webpack-dev-server, 其中加入了schema校验。

解决方法：
传递给webpack-dev-server时临时去除相关配置