### PR TITLE
fix(ko): #180 add immer and react-grid-layout to babel transpile for legacy browser

### DIFF
--- a/.changeset/happy-beans-speak.md
+++ b/.changeset/happy-beans-speak.md
@@ -1,0 +1,5 @@
+---
+'ko': patch
+---
+
+fix(ko): #180 add babel rule for monaco deps to support Chrome 66

--- a/packages/ko/package.json
+++ b/packages/ko/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.18.0",
+    "core-js": "^3.30.0",
     "@dtinsight/auto-polyfills-webpack-plugin": "workspace:2.0.0",
     "@nuxt/friendly-errors-webpack-plugin": "^2.5.2",
     "@parcel/css": "^1.12.2",

--- a/packages/ko/src/webpack/index.ts
+++ b/packages/ko/src/webpack/index.ts
@@ -97,7 +97,13 @@ class WebpackConfig {
             }),
         ].filter(Boolean),
         extensions: this.extensions,
-        alias,
+        alias: {
+          ...alias,
+          // 只 alias core-js v3 的 modules 路径，不影响 v2 的 library 路径
+          'core-js/modules': require
+            .resolve('core-js')
+            .replace(/\/index\.js$/, '/modules'),
+        },
         fallback: {
           fs: false,
           path: false,

--- a/packages/ko/src/webpack/loaders/script.ts
+++ b/packages/ko/src/webpack/loaders/script.ts
@@ -22,15 +22,59 @@ class Script {
           inline: 'fallback',
         },
       },
+      // Monaco worker 依赖专用规则（注入 corejs 兼容 chrome 66）
       {
         test: /\.m?(t|j)sx?$/,
         include: (input: string) => {
+          return (
+            input.includes('monaco-sql-languages') ||
+            input.includes('dt-sql-parser') ||
+            input.includes('antlr4ng') ||
+            input.includes('antlr4-c3')
+          );
+        },
+        use: [
+          {
+            loader: require.resolve('babel-loader'),
+            options: {
+              presets: [
+                [
+                  require.resolve('@babel/preset-env'),
+                  {
+                    useBuiltIns: 'usage',
+                    corejs: 3,
+                    targets: 'chrome >= 66',
+                  },
+                ],
+                [require.resolve('@babel/preset-typescript')],
+              ],
+              babelrc: false,
+              configFile: false,
+              cacheDirectory: true,
+              cacheCompression: false,
+            },
+          },
+        ],
+      },
+      {
+        test: /\.m?(t|j)sx?$/,
+        include: (input: string) => {
+          if (
+            input.includes('monaco-sql-languages') ||
+            input.includes('dt-sql-parser') ||
+            input.includes('antlr4ng') ||
+            input.includes('antlr4-c3')
+          ) {
+            return false;
+          }
           // internal modules dt-common compatible
           if (/node_modules[\\/]dt-common[\\/]src[\\/]/.test(input)) {
             return true;
-          } else if (input.includes('antlr4-c3')) {
+          } else if (input.includes('immer')) {
             return true;
-          } else if (input.includes('antlr4ng')) {
+          } else if (input.includes('react-grid-layout')) {
+            return true;
+          } else if (input.includes('monaco-editor')) {
             return true;
           } else if (input.includes('node_modules')) {
             return false;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,7 @@ importers:
       clean-webpack-plugin: ^4.0.0
       commander: ^9.2.0
       copy-webpack-plugin: ^11.0.0
+      core-js: ^3.30.0
       crypto-browserify: ^3.12.0
       css-loader: ^6.7.1
       css-minimizer-webpack-plugin: ^4.0.0
@@ -156,6 +157,7 @@ importers:
       clean-webpack-plugin: 4.0.0_webpack@5.76.2
       commander: 9.5.0
       copy-webpack-plugin: 11.0.0_webpack@5.76.2
+      core-js: 3.48.0
       crypto-browserify: 3.12.0
       css-loader: 6.7.3_webpack@5.76.2
       css-minimizer-webpack-plugin: 4.2.2_c2a19e8688155f5787d39be946a96e47
@@ -6573,6 +6575,11 @@ packages:
 
   /core-js/3.24.1:
     resolution: {integrity: sha512-0QTBSYSUZ6Gq21utGzkfITDylE8jWC9Ne1D2MrhvlsZBI1x39OdDIVbzSqtgMndIy6BlHxBXpMGqzZmnztg2rg==}
+    requiresBuild: true
+    dev: false
+
+  /core-js/3.48.0:
+    resolution: {integrity: sha512-zpEHTy1fjTMZCKLHUZoVeylt9XrzaIN2rbPXEt0k+q7JE5CkCZdo6bNq55bn24a69CH7ErAVLKijxJja4fw+UQ==}
     requiresBuild: true
     dev: false
 


### PR DESCRIPTION
https://github.com/DTStack/ko/issues/180

将 immer / react-grid-layout /  monaco-editor / monaco-sql-language 加入 babel-loader 的转义中，实现 chrome 66-80 正常访问

测试步骤  
Intel Mac 安装 Chrome 78，覆盖 62 各产品页面兼容性检查
1. 离线 / 实时 / 资产数据质量页面存在 immer 报错，需要处理
2. 离线需要额外处理 monacoEditor / monaco-sql-language， 同时 monaco-sql-language 中的 worker 需要被额外处理， 由于中的 monaco-sql-language 没有继承主配置里的 output.chunkFilename 需要在 ko 中配置默认 chunkFileName
3. 数据服务 & 标签 & 控制台 & 公共组件 & UIC 当前表现正常
4. 指标 / 指标应用存在 react-grid-layout 兼容性问题，需要处理
5. 需要 KO 额外协助处理 immer 与 react-grid-layout 两类问题