### PR TITLE
Fix 184 eslint config optimize

### DIFF
--- a/.changeset/quick-weeks-smell.md
+++ b/.changeset/quick-weeks-smell.md
@@ -1,0 +1,5 @@
+---
+'ko-lint-config': patch
+---
+
+optimize ts no-unused-vars

--- a/.changeset/quick-weeks-smell.md
+++ b/.changeset/quick-weeks-smell.md
@@ -1,5 +1,0 @@
----
-'ko-lint-config': patch
----
-
-optimize ts no-unused-vars

--- a/packages/ko-lint-config/.eslintrc.js
+++ b/packages/ko-lint-config/.eslintrc.js
@@ -218,6 +218,7 @@ module.exports = {
         argsIgnorePattern: '^_', // 函数参数忽略以下划线开头的变量
         destructuredArrayIgnorePattern: '^_', // 解构数组忽略以下划线开头的变量
         caughtErrorsIgnorePattern: '^err', // 捕获错误忽略以 err 开头的变量
+        ignoreRestSiblings: true, // 允许对象解构时忽略被排除字段
       },
     ],
 

--- a/packages/ko-lint-config/CHANGELOG.md
+++ b/packages/ko-lint-config/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ko-lint-config
 
+## 2.2.22
+
+### Patch Changes
+
+- 7d010512: optimize ts no-unused-vars
+
 ## 2.2.21
 
 ### Patch Changes

--- a/packages/ko-lint-config/package.json
+++ b/packages/ko-lint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ko-lint-config",
-  "version": "2.2.21",
+  "version": "2.2.22",
   "description": "lint configs about eslint stylelint and prettier",
   "main": "index.js",
   "files": [

--- a/packages/ko-lints/CHANGELOG.md
+++ b/packages/ko-lints/CHANGELOG.md
@@ -1,5 +1,12 @@
 # ko-lints
 
+## 4.0.22
+
+### Patch Changes
+
+- Updated dependencies [7d010512]
+  - ko-lint-config@2.2.22
+
 ## 4.0.21
 
 ### Patch Changes

--- a/packages/ko-lints/package.json
+++ b/packages/ko-lints/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ko-lints",
-  "version": "4.0.21",
+  "version": "4.0.22",
   "description": "lint tools used by ko",
   "keywords": [
     "ko",


### PR DESCRIPTION
- #184 

已发布 `ko-lints@4.0.22` 和 `ko-lint-config@2.2.22` 验证，合入后不需要再次执行 `pnpm  bump` 和 `pnpm release` 命令