### PR TITLE
feat(ko): #180 expose babelIncludes option for ES2020+ packages

### DIFF
--- a/.changeset/twelve-impalas-remain.md
+++ b/.changeset/twelve-impalas-remain.md
@@ -1,0 +1,5 @@
+---
+'ko': patch
+---
+
+feat(ko): #180 expose babelIncludes option for ES2020+ packages

--- a/packages/ko/src/core/config.ts
+++ b/packages/ko/src/core/config.ts
@@ -65,6 +65,7 @@ class Config {
         disableLazyImports: false,
       },
       autoPolyfills: false,
+      babelIncludes: [],
     };
   }
 }

--- a/packages/ko/src/types.ts
+++ b/packages/ko/src/types.ts
@@ -62,6 +62,22 @@ export type IOptions = {
    */
   plugins?: HookOptions[];
   /**
+   * Additional packages/paths to transpile via Babel, on top of ko's defaults.
+   *
+   * ko already transpiles these by default (they publish ES2020+ syntax):
+   * - `immer`
+   * - `react-grid-layout`
+   * - `monaco-editor`
+   * - internal `dt-common` source (`node_modules/dt-common/src/**`)
+   *
+   * You do not need to re-list them here. Use this to add your own
+   * ES2020+ packages that ko doesn't know about. Entries are matched
+   * as substring against the file path.
+   *
+   * @param {string[]}
+   */
+  babelIncludes?: string[];
+  /**
    * The path to the HTML template to use for the application.
    * @param {string}
    */

--- a/packages/ko/src/webpack/loaders/script.ts
+++ b/packages/ko/src/webpack/loaders/script.ts
@@ -76,7 +76,11 @@ class Script {
             return true;
           } else if (input.includes('monaco-editor')) {
             return true;
-          } else if (input.includes('node_modules')) {
+          }
+          if (this.opts.babelIncludes?.some(item => item && input.includes(item))) {
+            return true;
+          }
+          if (input.includes('node_modules')) {
             return false;
           } else {
             return true;


### PR DESCRIPTION
Expose a new `babelIncludes` option so users can include additional ES2020+ packages in babel transpilation. Resolves #180.